### PR TITLE
Solves functions_url_matcher.php warnings.

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -393,9 +393,6 @@ class listener implements EventSubscriberInterface
 							// request url is rewriten
 							// re-route request to app.php
 							global $phpbb_container; // god save the hax
-							$phpbb_root_path = $this->phpbb_root_path;
-							$phpEx = $this->php_ext;
-							include($phpbb_root_path . 'includes/functions_url_matcher.' . $phpEx);
 
 							// we need to overwrite couple SERVER variable to simulate direct app.php call
 							// start with scripts


### PR DESCRIPTION
Solves #3.
I didn't notice any side effects after deleting the code.

![image](https://user-images.githubusercontent.com/13873909/54223657-41524680-44f8-11e9-8826-827f72ceec4b.png)

The problem manifested when a user visited a page which was not a forum, whether existent or not, and whose URL did not contain a dot.